### PR TITLE
Add .babelrc & Fix Dependencies

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["es2015", "react", "stage-0"],
+}

--- a/README.MD
+++ b/README.MD
@@ -14,11 +14,17 @@ or you just want pages to be solid, don't jump when data was loaded.
 This package consist of 2 parts: one part allows you to delay containers rendering until some async actions are happening.
 Another stores your data to redux state and connect your loaded data to your container.
 
-## Installation & Usage
+## Installation
 
 Using [npm](https://www.npmjs.com/):
 
     $ npm install redux-async-connect
+
+Also, You need install babel presets as peer dependencies
+
+    $ npm install babel-preset-es2015 babel-preset-react babel-preset-stage-0
+
+## Usage
 
 ```js
 import { Router, browserHistory } from 'react-router';

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "git+ssh://git@github.com/Rezonans/redux-async-connect.git"
   },
   "scripts": {
-    "build": "babel ./modules --stage 0 --loose all -d lib --ignore '__tests__'",
+    "build": "babel ./modules -d lib --ignore '__tests__'",
     "lint": "eslint modules",
     "start": "babel-node example/server.js",
     "test": "npm run lint && karma start",
@@ -28,9 +28,9 @@
   },
   "homepage": "https://github.com/Rezonans/redux-async-connect",
   "peerDependencies": {
-    "react": "0.14.x",
-    "react-router": "2.0.0-rc5",
-    "react-redux": "4.0.x"
+    "babel-preset-es2015": "^6.3.13",
+    "babel-preset-react": "^6.3.13",
+    "babel-preset-stage-0": "^6.3.13"
   },
   "devDependencies": {
     "babel": "^5.8.34",
@@ -61,5 +61,8 @@
     "webpack": "^1.12.6",
     "webpack-dev-middleware": "^1.2.0",
     "eslint-config-airbnb": "^3.1.0"
+  },
+  "dependencies": {
+    "babel-cli": "^6.4.5"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -26,7 +26,7 @@ module.exports = {
 
     module: {
         loaders: [
-            { test: /\.js$/, exclude: /node_modules/, loader: 'babel?stage=0&loose=all' }
+            { test: /\.js$/, exclude: /node_modules/, loader: 'babel' }
         ]
     },
 


### PR DESCRIPTION
Currently, installing module causing errors like this:

```
> babel ./modules --stage 0 --loose all -d lib --ignore '__tests__'

sh: 1: babel: not found
```

and so on.

this PR fix those issues, but I think it has too many dependencies. have any idea?
