### PR TITLE
Babel 6 & prepublish

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["es2015", "react", "stage-0"],
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "git+ssh://git@github.com/Rezonans/redux-async-connect.git"
   },
   "scripts": {
-    "build": "babel ./modules --stage 0 --loose all -d lib --ignore '__tests__'",
+    "build": "babel ./modules -d lib --ignore '__tests__'",
     "lint": "eslint modules",
     "start": "babel-node example/server.js",
     "test": "npm run lint && karma start",
@@ -33,10 +33,13 @@
     "react-redux": "4.0.x"
   },
   "devDependencies": {
-    "babel": "^5.8.34",
-    "babel-core": "^5.8.34",
-    "babel-eslint": "^3.1.23",
-    "babel-loader": "^5.4.0",
+    "babel-cli": "^6.4.5",
+    "babel-core": "^6.4.5",
+    "babel-eslint": "^5.0.0-beta6",
+    "babel-loader": "^6.2.1",
+    "babel-preset-es2015": "^6.3.13",
+    "babel-preset-react": "^6.3.13",
+    "babel-preset-stage-0": "^6.3.13",
     "eslint": "1.4.1",
     "eslint-config-rackt": "1.0.0",
     "eslint-plugin-react": "3.3.2",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint": "eslint modules",
     "start": "babel-node example/server.js",
     "test": "npm run lint && karma start",
-    "postinstall": "node ./npm-scripts/postinstall.js"
+    "prepublish": "node ./npm-scripts/postinstall.js"
   },
   "keywords": [
     "redux",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -26,7 +26,7 @@ module.exports = {
 
     module: {
         loaders: [
-            { test: /\.js$/, exclude: /node_modules/, loader: 'babel?stage=0&loose=all' }
+            { test: /\.js$/, exclude: /node_modules/, loader: 'babel' }
         ]
     },
 


### PR DESCRIPTION
as @bdefore mentioned on #4, use `prepublish` instead of `postinstall`.
and also, add `.babelrc` & move to babel 6.

it seems like `npm run test`, `npm run lint` are not works, but that is not this PR's issues.
