### PR TITLE
Be more explicit in the way we declare deferred data

### DIFF
--- a/modules/asyncConnect.js
+++ b/modules/asyncConnect.js
@@ -6,8 +6,12 @@ export const LOAD_FAIL = 'reduxAsyncConnect/LOAD_FAIL';
 export const CLEAR = 'reduxAsyncConnect/CLEAR';
 export const BEGIN_GLOBAL_LOAD = 'reduxAsyncConnect/BEGIN_GLOBAL_LOAD';
 export const END_GLOBAL_LOAD = 'reduxAsyncConnect/END_GLOBAL_LOAD';
+const initialState = {
+  loaded: false,
+  deferredLoaded: true,
+};
 
-export function reducer(state = {loaded: false}, action = {}) {
+export function reducer(state = initialState, action = {}) {
   switch (action.type) {
     case BEGIN_GLOBAL_LOAD:
       return {
@@ -17,7 +21,8 @@ export function reducer(state = {loaded: false}, action = {}) {
     case END_GLOBAL_LOAD:
       return {
         ...state,
-        loaded: true
+        loaded: true,
+        deferredLoaded: !action.loadDeferred,
       };
     case LOAD:
       return {
@@ -81,8 +86,11 @@ export function beginGlobalLoad() {
   return { type: BEGIN_GLOBAL_LOAD };
 }
 
-export function endGlobalLoad() {
-  return { type: END_GLOBAL_LOAD };
+export function endGlobalLoad(loadDeferred = false) {
+  return {
+    type: END_GLOBAL_LOAD,
+    loadDeferred: loadDeferred,
+  };
 }
 
 function load(key) {


### PR DESCRIPTION
## What?

Dealing with deferred data is not working as expected for me. I've moved the code of this lib to my project and I've been playing with it to see how it works.

These are the changes necessary to make deferred works for me.
## What I mean with deferred?

I've see somewhere in the issues of this repo or in documentation that you can avoid fetching some of your data on the server with a filter like this:

In your component @asyncConect put the flag `deferred`:

``` javascript
@asyncConnect([{
  deferred: true,
  promise: (options) => {
    return options.store.dispatch(loadDeferredThing(options.params.id));
  },
}])
```

And then in your `client.js` or `server.js` filter items that are not deferred:

``` javascript
filter: (item) => !item.deferred,
```

:point_up: that way is not working for me.
## What I'm doing here?

With this changes you do not need to filter anything on server or client. You just need to declare the promise as `deferred` in your component and the lib take care of it.

This is working for me. The code can be improved but I just wanted to show you my idea.
