### PR TITLE
catching exception

### DIFF
--- a/modules/ReduxAsyncConnect.js
+++ b/modules/ReduxAsyncConnect.js
@@ -41,7 +41,12 @@ function loadAsyncConnect({components, filter = () => true, ...rest}) {
     const asyncItems = Component.reduxAsyncConnect;
 
     return Promise.all(asyncItems.reduce((itemsResults, item) => {
-      let promiseOrResult = item.promise(rest);
+      let promiseOrResult;
+      try {
+        promiseOrResult = item.promise(rest);
+      } catch (err) {
+        console.error(err);
+      }
 
       if (filter(item, Component)) {
         if (promiseOrResult && promiseOrResult.then instanceof Function) {


### PR DESCRIPTION
Hi,
I faced with the problem when a promise swallows exceptions.

I had this code:

``` javascript
@asyncConnect([{
  promise: ({store: {getState, dispatch}, params: {lectureId, moduleNumber}}) => {
    let state = getState();
    let lecture = state.activeLectures.list[lectureId].lecture; // HERE is an exception
    lecture = state.lectures.list[lecture];

    let lecturePromise = lecture ? Promise.resolve(lecture) : dispatch(loadSingle(lectureId));

    return lecturePromise.then(lecture => {
      let moduleId = typeof lecture.modules[moduleNumber] === 'string' ?
        lecture.modules[moduleNumber] : lecture.modules[moduleNumber]._id;

      return dispatch(loadSingleModule(moduleId));
    });
  }
}])
```

`state.activeLectures.list[lectureId]` is `undefined`, so it's impossible to read property `lecture`.
The code i added catches exceptions like the one in my code and show a message to the console.

I know, this is not the best solution and i prefer to return the error object, but for some reason .catch and Promise.reject doesn't work. I propose to improve the code and then merge it
