### PR TITLE
Log any exception when doing loadAsyncData

### DIFF
--- a/modules/ReduxAsyncConnect.js
+++ b/modules/ReduxAsyncConnect.js
@@ -138,6 +138,8 @@ class ReduxAsyncConnect extends React.Component {
             this.setState({propsToShow: props});
           }
           this.props.endGlobalLoad();
+        }).cache(e => {
+          console.error("Exception caught by ReduxAsyncConnect: ", e.stack);
         });
       })(loadDataCounter);
     } else {


### PR DESCRIPTION
Currently, if there're any exception happens after the data loaded & rendering the new view, this exception would be taken by the Promise. Therefore, it would appear `fine` but indeed.. users would see an empty screen because the view is not rendered properly due to exception.

This pull request tells the user that the exceptions happened indeed, and points to the developer where exactly is the exception (by logging the stacktrace)
