### PR TITLE
Fix markdown html escaping in render section

### DIFF
--- a/docs/API.MD
+++ b/docs/API.MD
@@ -15,7 +15,7 @@ Usually it is provided by react Router component or match method from react rout
 
 ##### `render` (required)
 Function that accepts props and uses to render components.
-Usually it's just <RouterContext {...props} /> (by default)
+Usually it's just `<RouterContext {...props} />` (by default)
 
 ##### `helpers`
 Any helpers you may want pass to your reduxAsyncConnect static method.


### PR DESCRIPTION
Small typo in the docs/API.md file
