### PR TITLE
Fix 'Accessing PropTypes via the main React package is deprecated.'

### DIFF
--- a/modules/ReduxAsyncConnect.js
+++ b/modules/ReduxAsyncConnect.js
@@ -1,9 +1,10 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import RouterContext from 'react-router/lib/RouterContext';
 import { beginGlobalLoad, endGlobalLoad } from './asyncConnect';
 import { connect } from 'react-redux';
 
-const { array, func, object, any } = React.PropTypes;
+const { array, func, object, any } = PropTypes;
 
 /**
  * We need to iterate over all components for specified routes.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-async-connect",
-  "version": "1.0.0-rc4",
+  "version": "1.0.1-rc4",
   "description": "It allows you to request async data, store them in redux state and connect them to your react component.",
   "main": "lib/index.js",
   "repository": {
@@ -28,8 +28,8 @@
   },
   "homepage": "https://github.com/Rezonans/redux-async-connect",
   "peerDependencies": {
-    "react": "0.14.x",
-    "react-router": "2.x.x",
+    "react": "15.x.x",
+    "react-router": "3.x.x",
     "react-redux": "4.x.x"
   },
   "devDependencies": {
@@ -57,9 +57,10 @@
     "karma-webpack": "^1.7.0",
     "mocha": "^2.0.1",
     "pretty-bytes": "^2.0.1",
-    "react": "^0.14.2",
-    "react-dom": "^0.14.2",
-    "react-router": "2.0.0-rc5",
+    "prop-types": "^15.5.8",
+    "react": "^15.5.4",
+    "react-dom": "^15.5.4",
+    "react-router": "3.0.5",
     "rimraf": "^2.4.2",
     "webpack": "^1.12.6",
     "webpack-dev-middleware": "^1.2.0",


### PR DESCRIPTION
Fix 'Accessing PropTypes via the main React package is deprecated.'